### PR TITLE
Add Gradle build configuration for Fabric 1.21.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Gradle
+.gradle/
+build/
+# Eclipse
+bin/
+# IntelliJ
+out/
+# Local libraries
+libs/*.jar

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # meteor-stash-mover
 https://www.youtube.com/watch?v=9Dm8lqE0pZk
-## A stash mover I made to move a large stash from the nether. I have only uploaded the module and won't make a release, because the code is very bad and this is not really meant for public use.
+## A stash mover I made to move a large stash from the nether. I have only uploaded the module and won't make a release, because
+ the code is very bad and this is not really meant for public use.
 ## Hopefully someone can learn from this and make it better :)
 
 ### PS: Thanks to [Divined](https://github.com/cmg-divined) for all the help with this.
+
+## Building
+
+This project now includes a minimal Gradle configuration targeting **Minecraft 1.21.4** with Fabric and Meteor Client. To build the mod:
+
+1. Place a compatible `baritone-api.jar` inside the [`libs/`](libs/) directory.
+2. Ensure you have Java 21 installed.
+3. Run `gradle build` to produce the mod JAR in `build/libs/`.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,34 @@
+plugins {
+    id 'fabric-loom' version '1.6-SNAPSHOT'
+}
+
+group = 'com.example'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+    maven { url 'https://maven.meteordev.org/releases' }
+}
+
+dependencies {
+    minecraft "com.mojang:minecraft:1.21.4"
+    mappings loom.yarnMappings("1.21.4+build.1")
+    modImplementation "net.fabricmc:fabric-loader:0.16.9"
+    modImplementation "meteordevelopment:meteor-client:0.5.9-1.21.4"
+    implementation files('libs/baritone-api.jar')
+    include files('libs/baritone-api.jar')
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.release = 21
+}
+
+tasks.jar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2G

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,0 +1,1 @@
+Place baritone-api.jar compatible with Minecraft 1.21.4 in this directory.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,9 @@
+pluginManagement {
+    repositories {
+        maven { url 'https://maven.fabricmc.net/' }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = 'meteor-stash-mover'


### PR DESCRIPTION
## Summary
- configure Gradle with Fabric Loom, Meteor Client, and local Baritone API
- add plugin repositories and Java 21 toolchain
- document build steps in README

## Testing
- `gradle build` *(fails: Could not create an instance of type net.fabricmc.loom.extension.LoomGradleExtensionImpl)*

------
https://chatgpt.com/codex/tasks/task_e_68a63401fefc83238189f859c7678cb1